### PR TITLE
fix: 审查退回修复 — 输入清理与方向键启动游戏

### DIFF
--- a/src/scenes/game.ts
+++ b/src/scenes/game.ts
@@ -29,6 +29,7 @@ export function startGame(app: Application): void {
   let tickTimer = 0
   let currentTickInterval = TICK_INTERVAL
   let lastTickTime = 0
+  let pendingDirection: Direction | null = null
 
   // DOM 元素
   const scoreEl = document.getElementById('score')!
@@ -81,6 +82,9 @@ export function startGame(app: Application): void {
     onDirection: (dir: Direction) => {
       if (state === GameState.PLAYING) {
         Snake.setDirection(dir)
+      } else if (state === GameState.READY || state === GameState.GAME_OVER || state === GameState.WIN) {
+        pendingDirection = dir
+        beginGame()
       }
     },
     onAction: () => {
@@ -249,6 +253,11 @@ export function startGame(app: Application): void {
     startBgm()
 
     Snake.createSnake(snakeLayer)
+    // 如果通过方向键启动，设置初始方向
+    if (pendingDirection) {
+      Snake.setDirection(pendingDirection)
+      pendingDirection = null
+    }
     resetScore()
     updateDisplay(scoreEl, highScoreEl)
     clearEffects()

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -17,6 +17,11 @@ interface InputCallbacks {
 
 let callbacks: InputCallbacks | null = null
 
+// 事件处理函数引用（用于 destroyInput 清理）
+let handleTouchStart: ((e: TouchEvent) => void) | null = null
+let handleTouchEnd: ((e: TouchEvent) => void) | null = null
+let dpadHandlers: { el: Element; fn: (e: Event) => void }[] = []
+
 /** 键盘按键到方向/动作的映射 */
 const KEY_MAP: Record<string, Direction> = {
   ArrowUp: Direction.UP, ArrowDown: Direction.DOWN,
@@ -46,6 +51,20 @@ export function initInput(cbs: InputCallbacks): void {
 /** 清理所有事件监听 */
 export function destroyInput(): void {
   document.removeEventListener('keydown', handleKeyDown)
+
+  const canvas = document.getElementById('gameCanvas')
+  if (canvas) {
+    if (handleTouchStart) canvas.removeEventListener('touchstart', handleTouchStart)
+    if (handleTouchEnd) canvas.removeEventListener('touchend', handleTouchEnd)
+  }
+  handleTouchStart = null
+  handleTouchEnd = null
+
+  for (const { el, fn } of dpadHandlers) {
+    el.removeEventListener('touchstart', fn)
+  }
+  dpadHandlers = []
+
   callbacks = null
 }
 
@@ -58,13 +77,13 @@ function initTouchSwipe(): void {
   let startX = 0
   let startY = 0
 
-  canvas.addEventListener('touchstart', (e: TouchEvent) => {
+  handleTouchStart = (e: TouchEvent) => {
     const touch = e.touches[0]
     startX = touch.clientX
     startY = touch.clientY
-  }, { passive: true })
+  }
 
-  canvas.addEventListener('touchend', (e: TouchEvent) => {
+  handleTouchEnd = (e: TouchEvent) => {
     if (!e.changedTouches.length) return
     const touch = e.changedTouches[0]
     const dx = touch.clientX - startX
@@ -79,7 +98,10 @@ function initTouchSwipe(): void {
     } else {
       callbacks?.onAction()
     }
-  })
+  }
+
+  canvas.addEventListener('touchstart', handleTouchStart, { passive: true })
+  canvas.addEventListener('touchend', handleTouchEnd)
 }
 
 // ========== 虚拟方向键 ==========
@@ -94,10 +116,12 @@ const DIR_MAP: Record<string, Direction> = {
 function initVirtualDpad(): void {
   const btns = document.querySelectorAll('.dpad-btn')
   btns.forEach(btn => {
-    btn.addEventListener('touchstart', (e) => {
+    const fn = (e: Event) => {
       e.preventDefault()
       const dir = DIR_MAP[(btn as HTMLElement).dataset.dir ?? '']
       if (dir) callbacks?.onDirection(dir)
-    })
+    }
+    btn.addEventListener('touchstart', fn)
+    dpadHandlers.push({ el: btn, fn })
   })
 }


### PR DESCRIPTION
## 关联 Issue
- 修复 #62 (L2 TASK-023: 输入系统迁移) — destroyInput() 未清理触屏和 dpad 事件监听器
- 修复 #65 (L3 TASK-026: 游戏场景集成与状态管理) — 方向键在非 PLAYING 状态下无法启动游戏

## 修复内容

### input.ts
- touchstart/touchend 处理函数提取为模块级变量
- dpad 按钮 handler 存入数组
- destroyInput() 中统一 removeEventListener

### game.ts
- onDirection 回调在 READY/GAME_OVER/WIN 状态下调用 beginGame() 并设置初始方向
- 新增 pendingDirection 变量，beginGame() 中应用

## 验证
- tsc --noEmit 零错误
- npm run build 构建成功